### PR TITLE
bump `byteslice` upper bound to `<0.3`

### DIFF
--- a/castagnoli.cabal
+++ b/castagnoli.cabal
@@ -23,7 +23,7 @@ library
     , primitive >=0.7 && <0.8
     , primitive-unlifted >=0.1 && <0.2
     , primitive-slice >=0.1 && <0.2
-    , byteslice >=0.1.1 && <0.2
+    , byteslice >=0.1.1 && <0.3
   hs-source-dirs: src
   ghc-options: -O2 -Wall
   default-language: Haskell2010


### PR DESCRIPTION
tested & works